### PR TITLE
Fix react peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   "peerDependencies": {
     "@inertiajs/react": "^1.0.0",
     "lodash.isequal": "^4.5.0",
-    "react": "^16.8.0"
+    "react": "^18.2.0"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -97,9 +97,9 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@inertiajs/react": "^1.0.2",
+    "@inertiajs/react": "^1.0.0",
     "lodash.isequal": "^4.5.0",
-    "react": "^18.2.0"
+    "react": "^16.9.0 || ^17.0.0 || ^18.0.0"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@inertiajs/react": "^1.0.0",
+    "@inertiajs/react": "^1.0.2",
     "lodash.isequal": "^4.5.0",
     "react": "^18.2.0"
   },


### PR DESCRIPTION
Hey, I think react needs to be updated to ^18.2.0 and inertia to ^1.0.2, because otherwise we get an error when running npm install (or we need to run with `npm install use-inertia-form --legacy-peer-deps`), which is not ideal for automated deploys.

Im on react ^18.0.26, and inertia 1.0.14, and npm install use-inertia-form throws dependency errors. If I update the peer deps, they seem to resolve.

Please check if this makes sense, and merge if possible. Thanks for the package!